### PR TITLE
AIOM 3.1.5

### DIFF
--- a/AllInOneMinify.module
+++ b/AllInOneMinify.module
@@ -68,7 +68,7 @@ class AllInOneMinify extends WireData implements Module, ConfigurableModule {
             // ------------------------------------------------------------------------
             // Version: major, minor, revision, i.e. 100 = 1.1.0
             // ------------------------------------------------------------------------
-            'version' => 314,
+            'version' => 315,
 
             'author' => 'David Karich & Conclurer GbR',
 
@@ -587,7 +587,7 @@ class AllInOneMinify extends WireData implements Module, ConfigurableModule {
                 // Load source of file and rewrite absolute URLs.
                 // ------------------------------------------------------------------------
                 $_css_src   = file_get_contents($stylesheet['absolute_path']).PHP_EOL;
-                $_css_src = (!empty($_css_src)) ? Minify_CSS_UriRewriter::rewrite($_css_src, dirname($stylesheet['absolute_path']),wire('config')->paths->root) : $_css_src;
+                $_css_src = (!empty($_css_src)) ? Minify_CSS_UriRewriter::rewrite($_css_src, dirname($stylesheet['absolute_path'])) : $_css_src;
 
                 // ------------------------------------------------------------------------
                 // If LESS file then run LESS parser.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ If you are currently in development of the site, caching can be a problem. For t
 
 ##Changelog##
 
+3.1.5
+
+* Bugfix: Links to images, which are embedded in CSS, are broken if the DOCUMENT_ROOT is not equal to ProcessWire root. 
+
 3.1.4
 
 * Bugfix: CacheFiles for Pages are now deleted when a new minimized file is created


### PR DESCRIPTION
Changes:
- Fixes a problem that broke links for images embedded in CSS code if ProcessWire root path is not equal to DOCUMENT_ROOT (#30)
