### PR TITLE
Fixed bug with $config->scripts support for JS() method

### DIFF
--- a/AllInOneMinify.module
+++ b/AllInOneMinify.module
@@ -419,7 +419,7 @@ class AllInOneMinify extends WireData implements Module, ConfigurableModule {
 
         // Support passing of $config->scripts as argument which is of type FilenameArray
         if(($javascripts instanceof FilenameArray))
-            $stylesheets = (array) $javascripts->getIterator(); // Convert to array
+            $javascripts = (array) $javascripts->getIterator(); // Convert to array
 
         // ------------------------------------------------------------------------
         // Check if files exist and generating the cache file name based 


### PR DESCRIPTION
I introduced a small cut/paste bug when introduced the new feature to support passing the $config->scripts array to the JS() method.
