### PR TITLE
Timestamps must be integers!!

### DIFF
--- a/AllInOneMinify.module
+++ b/AllInOneMinify.module
@@ -710,7 +710,7 @@ class AllInOneMinify extends WireData implements Module, ConfigurableModule {
         // Calculate timestamp of all files
         // ------------------------------------------------------------------------
         foreach ($files as $file) {
-            $_timestamp = ($_timestamp + $file['last_modified']);
+            $_timestamp = ((int)$_timestamp + (int)$file['last_modified']);
         }
 
         // ------------------------------------------------------------------------


### PR DESCRIPTION
I switched ProcessWire projects from one server to another and there was an error about mixing variable types. Both timestamps have to be integers.